### PR TITLE
Fix dump command: rename left-over field outcome_to_testnames.

### DIFF
--- a/jv
+++ b/jv
@@ -302,7 +302,7 @@ class TestRun:
             for outcome in OUTCOMES:
                 tr.begin_section('%s: %i tests'
                                  % (outcome, sumfile.get_count_by_outcome (outcome)))
-                for testname in sorted(sumfile.outcome_to_testnames[outcome]):
+                for testname in sorted(sumfile.outcome_to_testids[outcome]):
                     tr.writeln(testname)
                 tr.end_section()
             tr.end_section()


### PR DESCRIPTION
Fixes-up dc8ff270bfca4b623cb8ed8c45e82d3592d4e2bf

Sorry, could have been packed with previous PR.